### PR TITLE
Added an example of how to run extended tests on github actions

### DIFF
--- a/standards/general.Rmd
+++ b/standards/general.Rmd
@@ -551,7 +551,13 @@ should adhere to the following standards:
 
 - [**G5.10**]{#G5_10} *Extended tests should included and run under a common
   framework with other tests but be switched on by flags such as as
-  a `<MYPKG>_EXTENDED_TESTS=1` environment variable.*
+  a `<MYPKG>_EXTENDED_TESTS="true"` environment variable.*
+    - The extended tests can be then run automatically by GitHub Actions for 
+      example by adding the following to the `env` section of the workflow:
+      
+      `MYPKG_EXTENDED_TESTS: ${{contains(github.event.head_commit.message, 'run-extended')}}`
+      
+      Now the extended tests are run if the commit message contains phrase `run-extended`.
 - [**G5.11**]{#G5_11} *Where extended tests require large data sets or other
   assets, these should be provided for downloading and fetched as part of the
   testing workflow.*

--- a/standards/general.Rmd
+++ b/standards/general.Rmd
@@ -557,7 +557,7 @@ should adhere to the following standards:
       
       `MYPKG_EXTENDED_TESTS: ${{contains(github.event.head_commit.message, 'run-extended')}}`
       
-      Now the extended tests are run if the commit message contains phrase `run-extended`.
+      Extended tests will then be run in response to any commit message which contains the phrase `run-extended`.
 - [**G5.11**]{#G5_11} *Where extended tests require large data sets or other
   assets, these should be provided for downloading and fetched as part of the
   testing workflow.*


### PR DESCRIPTION
As discussed on slack, adds an example of how to run extended tests based on environment variables based on the tip by @mpadge.